### PR TITLE
Don't assume sub-second timestamp granularity

### DIFF
--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/spi/FilesystemWorkspace.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/spi/FilesystemWorkspace.java
@@ -43,7 +43,7 @@ public class FilesystemWorkspace implements Workspace {
     if (!isPresent(file)) {
       return ResourceStatus.REMOVED;
     }
-    if (length == file.length() && lastModified == file.lastModified()) {
+    if (length == file.length() && lastModified / 1000 == file.lastModified() / 1000) {
       return ResourceStatus.UNMODIFIED;
     }
     return ResourceStatus.MODIFIED;

--- a/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/FilesystemWorkspaceTest.java
+++ b/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/FilesystemWorkspaceTest.java
@@ -1,0 +1,24 @@
+package io.takari.incrementalbuild.spi;
+
+import static org.junit.Assert.assertEquals;
+import io.takari.incrementalbuild.workspace.Workspace;
+import io.takari.incrementalbuild.workspace.Workspace.ResourceStatus;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class FilesystemWorkspaceTest extends AbstractBuildContextTest {
+  @Test
+  public void testUnmodifiedResourceStatus() throws Exception {
+    final Workspace ws = new FilesystemWorkspace();
+    temp.newFile("test");
+    ws.walk(temp.getRoot(), new Workspace.FileVisitor() {
+      @Override
+      public void visit(File file, long lastModified, long length, ResourceStatus status) {
+        ResourceStatus currentStatus = ws.getResourceStatus(file, lastModified, length);
+        assertEquals(ResourceStatus.UNMODIFIED, currentStatus);
+      }
+    });
+  }
+}


### PR DESCRIPTION
Some operating systems or file systems may support file time stamps with one second granularity. On such systems compilation fails with `IllegalStateException: Unexpected input change`.

Related to PLXCOMP-241: https://github.com/sonatype/plexus-io/pull/5