### PR TITLE
Update junit to 4.12

### DIFF
--- a/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DefaultBuildContextTest.java
+++ b/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DefaultBuildContextTest.java
@@ -421,7 +421,7 @@ public class DefaultBuildContextTest extends AbstractBuildContextTest {
   @Test
   public void testRegisterInputs_directoryMatching() throws Exception {
     temp.newFolder("folder");
-    temp.newFolder("folder/subfolder");
+    temp.newFolder("folder", "subfolder");
     File f1 = temp.newFile("input1.txt");
     File f2 = temp.newFile("folder/input2.txt");
     File f3 = temp.newFile("folder/subfolder/input3.txt");

--- a/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DeltaWorkspaceTest.java
+++ b/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DeltaWorkspaceTest.java
@@ -188,8 +188,8 @@ public class DeltaWorkspaceTest extends AbstractBuildContextTest {
   @Test
   public void testCarryOverAndCleanup() throws Exception {
     File basedir = temp.newFolder("basedir").getCanonicalFile();
-    File inputdir = temp.newFolder("basedir/inputdir").getCanonicalFile();
-    File outputdir = temp.newFolder("basedir/outputdir").getCanonicalFile();
+    File inputdir = temp.newFolder("basedir", "inputdir").getCanonicalFile();
+    File outputdir = temp.newFolder("basedir", "outputdir").getCanonicalFile();
     File file = temp.newFile("basedir/inputdir/file.txt").getCanonicalFile();
 
     DeltaWorkspace workspace;

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <apache-maven.version>3.3.1</apache-maven.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
     <guava.version>18.0</guava.version>
     <eclipse-sisu.version>0.3.0</eclipse-sisu.version>
     <plugin-testing.version>2.2.0</plugin-testing.version>


### PR DESCRIPTION
Running takari-incrementalbuild tests with junit 4.12 causes the following error, which this pull request attempts to fix.

```
testCarryOverAndCleanup(io.takari.incrementalbuild.spi.DeltaWorkspaceTest)  Time elapsed: 0 sec  <<< ERROR!
java.io.IOException: Folder name cannot consist of multiple path components separated by a file separator. Please use newFolder('MyParentFolder','MyFolder') to create hierarchies of folders
    at org.junit.rules.TemporaryFolder.validateFolderName(TemporaryFolder.java:118)
    at org.junit.rules.TemporaryFolder.newFolder(TemporaryFolder.java:97)
    at org.junit.rules.TemporaryFolder.newFolder(TemporaryFolder.java:86)
    at io.takari.incrementalbuild.spi.DeltaWorkspaceTest.testCarryOverAndCleanup(DeltaWorkspaceTest.java:191)
```
