### PR TITLE
Use the same log format as maven-compiler-plugin

### DIFF
--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/spi/AbstractBuildContext.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/spi/AbstractBuildContext.java
@@ -549,13 +549,13 @@ public abstract class AbstractBuildContext {
       MessageSeverity severity, Throwable cause) {
     switch (severity) {
       case ERROR:
-        log.error("{}:[{}:{}] {}", resource.toString(), line, column, message, cause);
+        log.error("{}:[{},{}] {}", resource.toString(), line, column, message, cause);
         break;
       case WARNING:
-        log.warn("{}:[{}:{}] {}", resource.toString(), line, column, message, cause);
+        log.warn("{}:[{},{}] {}", resource.toString(), line, column, message, cause);
         break;
       default:
-        log.info("{}:[{}:{}] {}", resource.toString(), line, column, message, cause);
+        log.info("{}:[{},{}] {}", resource.toString(), line, column, message, cause);
         break;
     }
   }


### PR DESCRIPTION
This will allow netbeans integration at least. However there should be other tools that assumes log format to be the same as maven-compiler-plugin.