### PR TITLE
Option to skip creation of aggregated output if input set is empty

### DIFF
--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/AggregatorBuildContext.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/AggregatorBuildContext.java
@@ -27,4 +27,6 @@ public interface AggregatorBuildContext {
 
   public InputSet newInputSet();
 
+  public InputSet newInputSet(boolean createOutputIfEmpty);
+
 }

--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/internal/DefaultAggregatorBuildContext.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/internal/DefaultAggregatorBuildContext.java
@@ -38,7 +38,12 @@ public class DefaultAggregatorBuildContext extends AbstractBuildContext
 
   @Override
   public DefaultInputSet newInputSet() {
-    return new DefaultInputSet(this);
+    return newInputSet(true);
+  }
+
+  @Override
+  public DefaultInputSet newInputSet(boolean createOutputIfEmpty) {
+    return new DefaultInputSet(this, createOutputIfEmpty);
   }
 
   private File registerOutput(File outputFile) {

--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/internal/DefaultInputSet.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/aggregator/internal/DefaultInputSet.java
@@ -17,9 +17,11 @@ public class DefaultInputSet implements InputSet {
   private final DefaultAggregatorBuildContext context;
 
   private final Set<File> inputs = new LinkedHashSet<>();
+  private final boolean createOutputIfEmpty;
 
-  DefaultInputSet(DefaultAggregatorBuildContext context) {
+  DefaultInputSet(DefaultAggregatorBuildContext context, boolean createOutputIfEmpty) {
     this.context = context;
+    this.createOutputIfEmpty = createOutputIfEmpty;
   }
 
   @Override
@@ -44,12 +46,18 @@ public class DefaultInputSet implements InputSet {
   @Override
   public boolean aggregateIfNecessary(File outputFile, InputAggregator aggregator)
       throws IOException {
+    if (inputs.isEmpty() && !createOutputIfEmpty) {
+      return false;
+    }
     return context.aggregateIfNecessary(inputs, outputFile, aggregator);
   }
 
   @Override
   public <T extends Serializable> boolean aggregateIfNecessary(File outputFile,
       MetadataAggregator<T> aggregator) throws IOException {
+    if (inputs.isEmpty() && !createOutputIfEmpty) {
+      return false;
+    }
     return context.aggregateIfNecessary(inputs, outputFile, aggregator);
   }
 

--- a/incrementalbuild/src/main/java/io/takari/incrementalbuild/maven/internal/MavenAggregatorBuildContext.java
+++ b/incrementalbuild/src/main/java/io/takari/incrementalbuild/maven/internal/MavenAggregatorBuildContext.java
@@ -38,4 +38,9 @@ public class MavenAggregatorBuildContext implements AggregatorBuildContext {
     return provider.get().newInputSet();
   }
 
+  @Override
+  public InputSet newInputSet(boolean createOutputIfEmpty) {
+    return provider.get().newInputSet(createOutputIfEmpty);
+  }
+
 }

--- a/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DefaultAggregatorBuildContextTest.java
+++ b/incrementalbuild/src/test/java/io/takari/incrementalbuild/spi/DefaultAggregatorBuildContextTest.java
@@ -133,4 +133,18 @@ public class DefaultAggregatorBuildContextTest extends AbstractBuildContextTest 
     Assert.assertEquals(1, indexer.outputs.size());
   }
 
+  @Test
+  public void testEmptyNoCreate() throws Exception {
+    File outputFile = new File(temp.getRoot(), "output");
+    File basedir = temp.newFolder();
+
+    FileIndexer indexer = new FileIndexer();
+    DefaultAggregatorBuildContext actx = newContext();
+    DefaultInputSet output = actx.newInputSet(false);
+    output.addInputs(basedir, null, null);
+    output.aggregateIfNecessary(outputFile, indexer);
+    actx.commit(null);
+    Assert.assertFalse(outputFile.exists());
+    Assert.assertEquals(0, indexer.outputs.size());
+  }
 }


### PR DESCRIPTION
Will also address part of issue #15 