### PR TITLE
Add new interfaces to support optimized incremental builder state

### DIFF
--- a/incrementalbuild-workspace/src/main/java/io/takari/incrementalbuild/workspace/Workspace.java
+++ b/incrementalbuild-workspace/src/main/java/io/takari/incrementalbuild/workspace/Workspace.java
@@ -3,6 +3,7 @@ package io.takari.incrementalbuild.workspace;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Set;
 
 /**
  * {@code Workspace} provides a layer of indirection between BuildContext and underlying resource
@@ -59,4 +60,16 @@ public interface Workspace {
    * </ul>
    */
   public void walk(File basedir, FileVisitor visitor) throws IOException;
+
+  default public boolean isOptimizedBuildEnabled() {
+    return false;
+  }
+
+  default public boolean hasProjectDependenciesChanged() {
+    return true;
+  }
+
+  default public boolean hasDelta(Set<String> resources) {
+    return true;
+  }
 }


### PR DESCRIPTION
Add interfaces to support an optimistic implementation to identify whether
there is an incremental build needed for a builder based on its classpath,
configuration, inputs, outputs, and its reliance on project dependencies.

Signed-off-by: Saravanakumar A. Srinivasan <s.srinivasan@salesforce.com>