### PR TITLE
Update for Java 11

### DIFF
--- a/incrementalbuild-its/src/test/java/io/takari/incrementalbuild/maven/it/MavenIncrementalBuildTest.java
+++ b/incrementalbuild-its/src/test/java/io/takari/incrementalbuild/maven/it/MavenIncrementalBuildTest.java
@@ -15,7 +15,7 @@ import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.2.5", "3.3.1", "3.3.9"})
+@MavenVersions({"3.6.3"})
 public class MavenIncrementalBuildTest {
 
   @Rule

--- a/incrementalbuild-its/src/test/projects/buildextension/plugin/pom.xml
+++ b/incrementalbuild-its/src/test/projects/buildextension/plugin/pom.xml
@@ -40,7 +40,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.4</version>
+          <version>3.6.0</version>
           <configuration>
             <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           </configuration>
@@ -53,6 +53,11 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/incrementalbuild-its/src/test/projects/message/plugin/pom.xml
+++ b/incrementalbuild-its/src/test/projects/message/plugin/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.2</version>
+      <version>3.6.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -53,6 +53,11 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/incrementalbuild-its/src/test/projects/test-plugin/pom.xml
+++ b/incrementalbuild-its/src/test/projects/test-plugin/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.4</version>
+      <version>3.6.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -34,7 +34,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.4</version>
+          <version>3.6.0</version>
           <configuration>
             <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
           </configuration>
@@ -47,6 +47,11 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/incrementalbuild-workspace/pom.xml
+++ b/incrementalbuild-workspace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>io.takari.incrementalbuild</artifactId>
-    <version>0.20.9</version>
+    <version>0.20.10-SNAPSHOT</version>
   </parent>
   <artifactId>incrementalbuild-workspace</artifactId>
   <packaging>takari-jar</packaging>
@@ -13,7 +13,7 @@
   Provides hooks to run incremental build inside m2e workspace. Other host applications
   may also be able to use this API, but have not been tested.
 
-  Incremental build workspace API will be embedded in m2e, and therefore the same version 
+  Incremental build workspace API will be embedded in m2e, and therefore the same version
   of this API should work with multiple versions of incrementalbuild library. This means
   all changes to this API must be backwards compatible. This also means that changes to
   this API will require update to io.takari.m2e.lifecycle.
@@ -68,7 +68,7 @@
                 <_snapshot>${osgi-version-qualifier}</_snapshot>
 
                 <Bundle-SymbolicName>io.takari.incrementalbuild.workspace;singleton:=false</Bundle-SymbolicName>
-                <Bundle-RequiredExecutionEnvironment>JavaSE-1.7,JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
+                <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                 <Export-Package>io.takari.incrementalbuild.workspace,io.takari.incrementalbuild.classpath</Export-Package>
                 <Import-Package>!*</Import-Package>
               </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,9 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>takari</artifactId>
-    <version>24</version>
-    <!-- <version>18</version> -->
+    <version>28</version>
   </parent>
 
-  <groupId>io.takari</groupId>
   <artifactId>io.takari.incrementalbuild</artifactId>
   <version>0.20.10-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -41,22 +39,22 @@
   </developers>
 
   <properties>
-    <apache-maven.version>3.3.9</apache-maven.version>
-    <mavenPluginPlugin.version>3.4</mavenPluginPlugin.version>
-    <slf4j.version>1.7.5</slf4j.version>
+    <apache-maven.version>3.6.3</apache-maven.version>
+    <mavenPluginPlugin.version>3.6.0</mavenPluginPlugin.version>
+    <slf4j.version>1.7.30</slf4j.version>
     <junit.version>4.11</junit.version>
-    <guava.version>19.0</guava.version>
-    <eclipse-sisu.version>0.3.2</eclipse-sisu.version>
-    <plugin-testing.version>2.9.2</plugin-testing.version>
+    <guava.version>28.2-jre</guava.version>
+    <eclipse-sisu.version>0.3.4</eclipse-sisu.version>
+    <plugin-testing.version>2.9.3-SNAPSHOT</plugin-testing.version>
+    <takariLifecycleVersion>1.13.9</takariLifecycleVersion>
     <takari.javaSourceVersion>1.8</takari.javaSourceVersion>
-    <takariLifecycleVersion>1.12.1</takariLifecycleVersion>
-    <classworlds.version>2.5.2</classworlds.version>
+    <classworlds.version>2.6.0</classworlds.version>
     <takari.transitiveDependencyReference>error</takari.transitiveDependencyReference>
     <takari.privatePackageReference>ignore</takari.privatePackageReference>
     <incrementalbuild-workspace.version>0.20.9</incrementalbuild-workspace.version>
     <takari-builder-security-manager.version>0.20.5</takari-builder-security-manager.version>
-    <maven-resolver.version>1.1.0</maven-resolver.version>
-    <maven-wagon.version>3.0.0</maven-wagon.version>
+    <maven-resolver.version>1.4.1</maven-resolver.version>
+    <maven-wagon.version>3.3.4</maven-wagon.version>
   </properties>
 
   <modules>
@@ -64,7 +62,7 @@
       | Changes to incrementalbuild-workspace and takari-builder-security-manager require update to
       | io.takari.m2e.lifecycle and should be avoided if possible.
       | To emphasise this, these projects are not normally part
-      | of io.takari.incrementalbuild build and special steps are required to produce new builds 
+      | of io.takari.incrementalbuild build and special steps are required to produce new builds
       | and release new versions.
       |
       | To start work on new incrementalbuild-workspace or takari-builder-security-manager version
@@ -85,12 +83,12 @@
       | - mvn org.eclipse.tycho:tycho-versions-plugin:0.20.0:set-version -DnewVersion=<next-version>
       | - git commit -asm "prepare for next development iteration"
       |
-    
+
      -->
-     
+
     <!-- <module>incrementalbuild-workspace</module> -->
     <!-- <module>takari-builder-security-manager</module> -->
-    
+
     <module>incrementalbuild</module>
     <module>incrementalbuild-its</module>
     <module>takari-builder</module>
@@ -145,7 +143,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.0.22</version>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -203,12 +201,12 @@
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-api</artifactId>
-        <version>1.1.0</version>
+        <version>${maven-resolver.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-util</artifactId>
-        <version>1.1.0</version>
+        <version>${maven-resolver.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.enterprise</groupId>
@@ -218,9 +216,9 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.0</version>
+        <version>4.2.2</version>
         <classifier>no_aop</classifier>
-      </dependency>    
+      </dependency>
 
       <!-- test dependencies -->
       <dependency>
@@ -268,19 +266,19 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.5.2</version>
+        <version>3.14.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.testing.compile</groupId>
         <artifactId>compile-testing</artifactId>
-        <version>0.10</version>
+        <version>0.18</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>0.30</version>
+        <version>0.45</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -323,19 +321,19 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-resolver-provider</artifactId>
-        <version>3.5.2</version>
+        <version>${apache-maven.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
-  
+
   <build>
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.15</version>
+          <version>1.18</version>
           <configuration>
             <signature>
               <groupId>org.codehaus.mojo.signature</groupId>
@@ -344,8 +342,13 @@
             </signature>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
-  
+
 </project>

--- a/takari-builder-demo/src/test/java/io/takari/builder/demo/CopyFilesMavenIntegrationTest.java
+++ b/takari-builder-demo/src/test/java/io/takari/builder/demo/CopyFilesMavenIntegrationTest.java
@@ -21,7 +21,7 @@ import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
  * {@link MavenVersions} test annotation.
  */
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.3.9"})
+@MavenVersions({"3.6.3"})
 public class CopyFilesMavenIntegrationTest {
 
   @Rule

--- a/takari-builder-enforcer/src/test/java/io/takari/builder/enforcer/modularity/internal/ModularityEnforcerIntegrationTest.java
+++ b/takari-builder-enforcer/src/test/java/io/takari/builder/enforcer/modularity/internal/ModularityEnforcerIntegrationTest.java
@@ -13,7 +13,7 @@ import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.3.9"})
+@MavenVersions({"3.6.3"})
 public class ModularityEnforcerIntegrationTest {
 
   @Rule
@@ -67,7 +67,7 @@ public class ModularityEnforcerIntegrationTest {
         .assertLogText("[ERROR] W")
         .assertLogText("Unexpected filesystem access for project: enforce")
         .assertLogText("Violated Rules Are:").assertLogText("  W ").assertLogText(
-            "/target/test-projects/ModularityEnforcerIntegrationTest_testEnforceLogOnlyWithCommandLineProp[3.3.9]_enforce/**");
+            "/target/test-projects/ModularityEnforcerIntegrationTest_testEnforceLogOnlyWithCommandLineProp[3.6.3]_enforce/**");
   }
 
   @Test

--- a/takari-builder-enforcer/src/test/java/io/takari/builder/enforcer/modularity/internal/ModularityEnforcerTestUtil.java
+++ b/takari-builder-enforcer/src/test/java/io/takari/builder/enforcer/modularity/internal/ModularityEnforcerTestUtil.java
@@ -48,6 +48,11 @@ public class ModularityEnforcerTestUtil {
       Collection<MavenProject> dependencies = this.dependencies.get(project);
       return dependencies == null ? ImmutableList.of() : ImmutableList.copyOf(dependencies);
     }
+
+    @Override
+    public List<MavenProject> getAllProjects() {
+      return ImmutableList.copyOf(dependents.values()); // this is probably wrong
+    }
   }
 
   public static class Builder {

--- a/takari-builder-enforcer/src/test/projects/multimodule-apt-it/m1/pom.xml
+++ b/takari-builder-enforcer/src/test/projects/multimodule-apt-it/m1/pom.xml
@@ -26,5 +26,11 @@
 	  <version>1.2</version>
 	  <scope>provided</scope>
 	</dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/takari-builder-enforcer/src/test/projects/multimodule-apt-it/m2/pom.xml
+++ b/takari-builder-enforcer/src/test/projects/multimodule-apt-it/m2/pom.xml
@@ -20,5 +20,11 @@
 	  <version>1.2</version>
 	  <scope>provided</scope>
 	</dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/takari-builder-enforcer/src/test/projects/multimodule-apt-it/pom.xml
+++ b/takari-builder-enforcer/src/test/projects/multimodule-apt-it/pom.xml
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>1.12.1</version>
+        <version>1.13.9</version>
         <configuration>
           <proc>only</proc>
           <source>1.8</source>

--- a/takari-builder-security-manager/pom.xml
+++ b/takari-builder-security-manager/pom.xml
@@ -3,9 +3,9 @@
   <parent>
     <groupId>io.takari</groupId>
     <artifactId>io.takari.incrementalbuild</artifactId>
-    <version>0.20.5</version>
+    <version>0.20.10-SNAPSHOT</version>
   </parent>
-  
+
   <groupId>io.takari.builder</groupId>
   <artifactId>takari-builder-security-manager</artifactId>
 
@@ -36,7 +36,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>
@@ -74,7 +74,7 @@
                 <_nouses>true</_nouses>
                 <_nodefaultversion>true</_nodefaultversion>
                 <_snapshot>${osgi-version-qualifier}</_snapshot>
-                
+
                 <Import-Package>
                   org.slf4j;version="1.6.2"
                 </Import-Package>
@@ -82,7 +82,7 @@
                 <Bundle-SymbolicName>io.takari.builder.takari-builder-security-manager;singleton:=false</Bundle-SymbolicName>
                 <Bundle-RequiredExecutionEnvironment>JavaSE-1.8</Bundle-RequiredExecutionEnvironment>
                 <Export-Package>io.takari.builder.enforcer</Export-Package>
-                
+
               </instructions>
             </configuration>
           </execution>
@@ -118,5 +118,5 @@
       </build>
     </profile>
   </profiles>
-  
+
 </project>

--- a/takari-builder/src/test/java/io/takari/builder/internal/maven/LegacyMojoWhitelistMavenTest.java
+++ b/takari-builder/src/test/java/io/takari/builder/internal/maven/LegacyMojoWhitelistMavenTest.java
@@ -13,7 +13,7 @@ import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 
 @RunWith(MavenJUnitTestRunner.class)
-@MavenVersions({"3.3.9"})
+@MavenVersions({"3.6.3"})
 public class LegacyMojoWhitelistMavenTest {
 
   @Rule

--- a/takari-builder/src/test/projects/redundant-whitelist/builder/pom.xml
+++ b/takari-builder/src/test/projects/redundant-whitelist/builder/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.3.9</version>
+      <version>3.6.3</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>io.takari.maven.plugins</groupId>
         <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>1.12.2</version>
+        <version>1.13.9</version>
         <extensions>true</extensions>
         <configuration>
           <proc>none</proc>


### PR DESCRIPTION
In order to build successfully with JDK 11 Maven and all its
dependencies must be updated to a Maven version which supports JDK 11.

This also drops support for older Maven versions (<3.6.3).

Compilation with JDK 8 still works.

_There is a behavioral change in JDK 11 which potentially breaks Takari's Security Manager (#36)._